### PR TITLE
Add index.ts to expose main classes more conveniently

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.1",
   "description": "",
   "type": "module",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "rollup -c",
     "prepack": "yarn build",

--- a/src/conductor/runner/index.ts
+++ b/src/conductor/runner/index.ts
@@ -1,2 +1,4 @@
 export { BasicEvaluator } from "./BasicEvaluator";
 export { RunnerPlugin } from "./RunnerPlugin";
+
+export { IRunnerPlugin, IEvaluator, IInterfacableEvaluator, EvaluatorClass } from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,8 @@
+// Export plugins
+export { BasicHostPlugin } from './conductor/host/BasicHostPlugin';
+export { IHostPlugin } from './conductor/host/types';
+
+// Export conduit
+export { Conduit } from './conduit';
+export { IConduit } from './conduit/types';
+export { IChannel, IPlugin, PluginClass, Subscriber } from './conduit/types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,7 @@ export * from "./conductor/module";
 export * from "./conductor/runner";
 export * from "./conductor/stdlib";
 export * from "./conductor/strings";
+
+// Export common errors
+export { ConductorError, EvaluatorTypeError } from "./common/errors";
+export { EvaluatorError } from "./common/errors/EvaluatorError";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
-// Export plugins
-export { BasicHostPlugin } from './conductor/host/BasicHostPlugin';
-export { IHostPlugin } from './conductor/host/types';
+// Export everything from conduit
+export * from "./conduit";
 
-// Export conduit
-export { Conduit } from './conduit';
-export { IConduit } from './conduit/types';
-export { IChannel, IPlugin, PluginClass, Subscriber } from './conduit/types';
+// Export conductor-related modules
+export * from "./conductor/host";
+export * from "./conductor/util";
+export * from "./conductor/types";
+export * from "./conductor/module";
+export * from "./conductor/runner";
+export * from "./conductor/stdlib";
+export * from "./conductor/strings";


### PR DESCRIPTION
This PR includes the missing package entry point of `index.js`. It also moves the file to `dist/index.js` instead.

<img width="1432" height="325" alt="image" src="https://github.com/user-attachments/assets/ad6d3903-9240-499b-be3a-d3993735dd69" />

### Motivation: main classes and types are exposed more conveniently

Currently, consumers of `@sourceacademy/conductor` need to import from deep paths such as:

```ts
import type { IChannel } from "@sourceacademy/conductor/dist/conduit/Channel";
```

This makes imports fragile and harder to maintain.

This PR enables import from the package root:

```ts
import { BasicHostPlugin, InternalChannelName } from "@sourceacademy/conductor";
import type { ConductorError, IConduit, IChannel } from "@sourceacademy/conductor";
```